### PR TITLE
Check for search dim mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 *~
+
+# vscode
+.vscode

--- a/hnsqlite/collection.py
+++ b/hnsqlite/collection.py
@@ -535,6 +535,10 @@ class Collection :
         """
         if isinstance(vector, list):
             vector = np.array(vector)
+
+        vector_dim = vector.shape[0]
+        if vector_dim != self.config.dim:
+            raise ValueError(f"Dim mismatch: vector: {vector_dim}, collection: {self.config.dim}")
         
         def _filter(id):
             with Session(self.db_engine) as session:

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -112,7 +112,7 @@ class TestCollection2(unittest.TestCase):
         logger.info("test_search_invalid")
         collection = Collection("test-collection7", 128)
         vector = np.random.rand(64).astype(np.float32)  # Wrong length
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             collection.search(vector)
 
 

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -1,6 +1,6 @@
 
 import unittest
-from filter import filter_item
+from hnsqlite.filter import filter_item
 
 class TestFilterItem(unittest.TestCase):
     def test_filter_item(self):


### PR DESCRIPTION
... to prevent downstream memory / segfault issues.

With a clean hnsqlite Python 3.10 venv and latest project deps on a Mac, the `TestCollection2.test_search_invalid` test fails for me with either
```
Python(39103,0x10bba4600) malloc: Incorrect checksum for freed object 0x7fa668a7d508: probably modified after being freed. Corrupt value: 0x8000000000000000
```

or occasionally an outright `segmentation fault`.

This PR adds a simple dim mismatch check in `Collection.search`.