### PR TITLE
Specify custom directory for index files

### DIFF
--- a/hnsqlite/util.py
+++ b/hnsqlite/util.py
@@ -1,8 +1,8 @@
 import hashlib
 import re
 
-def md5_file(filename):
-    with open(filename, 'rb') as f:
+def md5_file(file_path):
+    with open(file_path, 'rb') as f:
         md5 = hashlib.md5()
         while True:
             data = f.read(1024*1024)


### PR DESCRIPTION
Further to #6:

- `index_file_dir` can be optionally set at collection level; otherwise defaults to current dir per existing behaviour
- a couple of tests added (tests can now use a `TemporaryDirectory`)